### PR TITLE
fix notification consumer triggering "attribute not found"

### DIFF
--- a/notifications/consumers.py
+++ b/notifications/consumers.py
@@ -61,7 +61,7 @@ class NotificationsConsumer(AuthWebsocketConsumer):
             )
 
     async def disconnect(self, code):
-        if self.room_group_name:
+        if hasattr(self, "room_group_name"):
             await self.channel_layer.group_discard(
                 self.room_group_name, self.channel_name
             )

--- a/notifications/consumers.py
+++ b/notifications/consumers.py
@@ -61,7 +61,7 @@ class NotificationsConsumer(AuthWebsocketConsumer):
             )
 
     async def disconnect(self, code):
-        if hasattr(self, "room_group_name"):
+        if hasattr(self, "room_group_name") and self.room_group_name:
             await self.channel_layer.group_discard(
                 self.room_group_name, self.channel_name
             )


### PR DESCRIPTION
fix notification consumer triggering "attribute not found"
exceptions on disconnect